### PR TITLE
cargo is included in the rust dependency

### DIFF
--- a/komplexity/meta.yaml
+++ b/komplexity/meta.yaml
@@ -7,8 +7,7 @@ source:
 
 requirements:
   build:
-    - rust # >1.21.0 #can be found in clinicalgraphics channel
-    - cargo
+    - rust
 
   run:
     - rust


### PR DESCRIPTION
this builds correctly when using the `conda-forge` channel